### PR TITLE
Update PurgeCSS' `defaultExtractor` to keep TailwindUI classes

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -86,7 +86,7 @@ TailwindPlugin.defaultOptions = () => ({
       />>>/,
       /::v-deep/
     ],
-    defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || []
+    defaultExtractor: content => content.match(/[\w-/.:]+(?<!:)/g) || []
   }
 });
 


### PR DESCRIPTION
Closes #33.